### PR TITLE
Fixed _config.yml gems line indentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ paginate:         5
 
 # Custom vars
 version:          2.1.0
-   gems: [jekyll-paginate]
+gems: [jekyll-paginate]
 
 github:
   repo:           https://github.com/poole/hyde


### PR DESCRIPTION
Fixed _config.yml gems line indentation, was causing build errors on Windows and Linux.  File verified with yamllint.com
