### PR TITLE
change gems to plugins  

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ paginate:         5
 
 # Custom vars
 version:          2.1.0
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 
 github:
   repo:           https://github.com/poole/hyde


### PR DESCRIPTION
gems was changed to plugins in jekyll, change needed for compatibility with new versions 